### PR TITLE
Fix showing weekly summary from previous year for current month

### DIFF
--- a/src/Adliance.Togglr/CalculationService.cs
+++ b/src/Adliance.Togglr/CalculationService.cs
@@ -10,7 +10,7 @@ public class CalculationService
 {
     private UserConfiguration User { get; }
     public IDictionary<DateTime, Day> Days { get; }
-    public IDictionary<(int, int), Week> Weeks { get; }
+    public IDictionary<(int year, int month, int weekNumber), Week> Weeks { get; }
 
     public CalculationService(UserConfiguration user, IList<DetailedReportDatum> entries, DateTime homeOfficeStart)
     {
@@ -78,7 +78,7 @@ public class CalculationService
         }
 
         Days = days.OrderBy(x => x.Date).ToDictionary(x => x.Date, x => x);
-        Weeks = new Dictionary<(int, int), Week>();
+        Weeks = new Dictionary<(int year, int month, int weekNumber), Week>();
         AddMissingDays();
         CalculateRollingOvertime();
         CalculateRollingVacation();
@@ -172,7 +172,7 @@ public class CalculationService
             currentWeek.BusinessTripHours += d.BusinessTripHours;
             currentWeek.BreakDuration += d.Breaks;
 
-            Weeks[(d.Date.Month, d.Date.GetWeekNumber())] = currentWeek;
+            Weeks[(d.Date.Year, d.Date.Month, d.Date.GetWeekNumber())] = currentWeek;
         }
     }
 

--- a/src/Adliance.Togglr/DayStatistics.cs
+++ b/src/Adliance.Togglr/DayStatistics.cs
@@ -52,9 +52,9 @@ public static class DayStatistics
                 WriteDay(configuration, sb, calculationService.Days[loopDate.Date]);
             }
             
-            if (loopDate.Date.DayOfWeek == DayOfWeek.Sunday && calculationService.Weeks.ContainsKey((loopDate.Date.Month, loopDate.Date.GetWeekNumber())))
+            if (loopDate.Date.DayOfWeek == DayOfWeek.Sunday && calculationService.Weeks.ContainsKey((loopDate.Date.Year, loopDate.Date.Month, loopDate.Date.GetWeekNumber())))
             {
-                WriteWeeklySummary(configuration, sb, calculationService.Weeks[(loopDate.Date.Month, loopDate.Date.GetWeekNumber())]);
+                WriteWeeklySummary(configuration, sb, calculationService.Weeks[(loopDate.Date.Year, loopDate.Date.Month, loopDate.Date.GetWeekNumber())]);
                 printedWeeklySummary = true;
             }
 
@@ -68,8 +68,8 @@ public static class DayStatistics
             shouldPrintDay = shouldPrintDay && (!configuration.PrintDetailsEnd.HasValue || lastDay <= configuration.PrintDetailsEnd.Value.Date);
             shouldPrintDay = shouldPrintDay && calculationService.Days.ContainsKey(lastDay);
             
-            if (shouldPrintDay && calculationService.Weeks.ContainsKey((lastDay.Month, lastDay.GetWeekNumber())))
-                WriteWeeklySummary(configuration, sb, calculationService.Weeks[(lastDay.Month, lastDay.GetWeekNumber())]);
+            if (shouldPrintDay && calculationService.Weeks.ContainsKey((lastDay.Year, lastDay.Month, lastDay.GetWeekNumber())))
+                WriteWeeklySummary(configuration, sb, calculationService.Weeks[(lastDay.Year, lastDay.Month, lastDay.GetWeekNumber())]);
         }
 
         sb.AppendLine("</tbody>");


### PR DESCRIPTION
I added the year to the dictionary for the weekly summaries to avoid printing weeks from the previous year.

Before this, it would print weekly summaries for the rest of the current month.