### PR TITLE
Display times worked on days, where no work was expected

### DIFF
--- a/src/Adliance.Togglr/DayStatistics.cs
+++ b/src/Adliance.Togglr/DayStatistics.cs
@@ -82,7 +82,7 @@ public static class DayStatistics
         sb.AppendLine($"<tr class=\"{(day.Expected <= 0 ? "has-text-grey-light" : "")}\">");
         sb.AppendLine($"<td>{day.Date:dddd, dd.MM.yyyy}</td>");
 
-        if (day.Expected > 0)
+        if (day.Expected > 0 || day.Total > 0)
         {
             if (day.PrintTimes)
             {


### PR DESCRIPTION
Previously, only the overtime was shown on days, where no work was expected. Now, the same information as on expected days is shown in a light gray.