### PR TITLE
Update Dockerfile to .NET9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS builder
 
 WORKDIR /src
 
@@ -10,10 +10,10 @@ RUN apt-get update -y && \
     dotnet pack && \
     dotnet tool install --global --add-source ./nupkg adliance.togglr
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0 AS runtime
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS runtime
 
 WORKDIR /app
-COPY --from=builder /src/Adliance.Togglr/bin/Debug/net7.0/publish/ /app/
+COPY --from=builder /src/Adliance.Togglr/bin/Release/net9.0/publish/ /app/
 RUN apt-get update -y && \
     apt-get upgrade -y
 


### PR DESCRIPTION
Currently, using the Dockerfile does not work because of mismatching .NET versions.

This PR updates the Dockerfile so it is compatible with the rest of the app (which uses [.NET9](https://github.com/silvester-pari/Togglr/commit/ed98505646a0810df31d50d8bd36d6b7b846b4f4)).