### PR TITLE
Fallback to current year if empty tickets list

### DIFF
--- a/src/Adliance.Togglr/Report/TicketDataService.cs
+++ b/src/Adliance.Togglr/Report/TicketDataService.cs
@@ -11,8 +11,8 @@ public class TicketDataService(List<DetailedReportDatum> allEntries)
 {
     public List<TicketProjectData> Projects { get; } = new();
     public List<UnbookedTicketData> UnbookedTickets { get; } = new();
-    public int MinYear => Projects.SelectMany(x => x.Tickets).Min(x => x.End.Year);
-    public int MaxYear => Projects.SelectMany(x => x.Tickets).Max(x => x.End.Year);
+    public int MinYear => Projects.SelectMany(x => x.Tickets).Select(x => x.End.Year).DefaultIfEmpty(DateTime.Now.Year).Min();
+    public int MaxYear => Projects.SelectMany(x => x.Tickets).Select(x => x.End.Year).DefaultIfEmpty(DateTime.Now.Year).Max();
 
     public void Calculate()
     {


### PR DESCRIPTION
Currently, running the program for certain configurations causes an error:

```
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.MaxInteger[TSource,TResult](IEnumerable`1 source, Func`2 selector)
   at Adliance.Togglr.Report.TicketDataService.get_MaxYear() in /src/Adliance.Togglr/Report/TicketDataService.cs:line 15
```

In order to fix this, this PR handles the case where the sequence of tickets is empty by providing a default value (current year).