### PR TITLE
Extended caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ While team members use Toggl to track their normal working time to work-related 
 ```
 
 ### Optional: Cache specification
-Optionally a year can be specified, until which all entries remain in a cache file and won't be downloaded each time the tool gets started. The specified year is included in the cache:
+Since Togglr v1.3.x all entries are cached in `entries.json`. Each run per default the last 45 days are getting newly fetched from Togglr. This prevents exceeding the API limit for updating the entries.
+The value of 45 days can be adapted using the following configuration entry:
 ```
-  "cache_entries_until_year": 2021
+  "use_old_entries_x_days_back": 60
 ```
 
 ### Required: Team Members

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 1.2.$(Rev:r)
+name: 1.3.$(Rev:r)
 
 variables:
   - group: shared_buddy_variable_group

--- a/src/Adliance.Togglr/Configuration.cs
+++ b/src/Adliance.Togglr/Configuration.cs
@@ -26,11 +26,12 @@ public class Configuration
     [JsonProperty("print_details_end")] public DateTime? PrintDetailsEnd { get; set; }
 
     [JsonProperty("homeoffice_start")] public DateTime? HomeOfficeStart { get; set; }
+
     /// <summary>
-    /// Optional property which allows caching all Toggl entries until a given year to avoid always downloading old entries, which won't get changed anyways.
-    /// (specified year included)
+    /// Determines X days in the past until which old entries are taken from cache file.
+    /// Newer entries >= X are always fetched freshly from Toggl as they may have been changed.
     /// </summary>
-    [JsonProperty("cache_entries_until_year")] public int? CacheEntriesUntilYear { get; set; }
+    [JsonProperty("use_old_entries_x_days_back")] public int UseOldEntriesXDaysBack { get; set; } = 45;
 }
 
 public class UserConfiguration

--- a/src/Adliance.Togglr/Report/ReportService.cs
+++ b/src/Adliance.Togglr/Report/ReportService.cs
@@ -39,9 +39,9 @@ public class ReportService(ReportParameter reportParameter)
 
         Program.Logger.Trace($"Loaded configuration with {Configuration.Users.Count} configured users.");
 
-        var togglClient = new TogglClient();
-        await togglClient.DownloadEntriesAndStoreLocally(Configuration);
-        AllEntries = togglClient.LoadEntriesLocallyAndFix(Configuration);
+        var togglClient = new TogglClient(Configuration);
+        await togglClient.DownloadEntriesAndStoreLocally();
+        AllEntries = togglClient.LoadEntriesLocallyAndFix();
 
         Program.Logger.Info("Working on the tickets ...");
         var ticketsService = new TicketReportService(reportParameter);


### PR DESCRIPTION
Toggl is introducing [API request limits](https://support.toggl.com/en/articles/11484112-api-webhook-limits-are-changing) per 5th of September 2025 which is restricting usage quite heavily, especially for free users.

The limits are as follows:
- Free: 30 requests per hour
- Starter: 240 requests per hour
- Premium: 600 requests per hour

As the detailed reports we require are paginated each 50 entries, the amount of requests is increasing the further we progress in the year.

Therefore this PR changes the behavior of caching and per default caches all entries, however each run per default the last 45 days are getting newly fetched, as they most like have adaptions.
The default value can be adapted using the configuration
```
  "use_old_entries_x_days_back": 60
```

**🚨 Breaking change:**
As the entries are cached now up to the current date a file named `entries_until_20xx.json` is not used anymore. All entries are getting stored in `entries.json`.
Either remove your existing json files and re-download all entries (this works until the API requests limit is getting enforced) or remove your `entries.json` file and rename your `entries_until_20xx.json` to `entries.json`.
This preserves your time tracking history and downloads all missing entries from 20xx up to now.