### PR TITLE
Docker usage enhancement for entries.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ After the successful build, you can generate the configuration, but you need to 
 mkdir conf && docker run --rm --name togglr -v ${PWD}/conf:/conf local/togglr:latest generate-configuration -t /conf/configuration.json
 ```
 
-Change the configuration.json to your needs - see [Configuration](#configuration), afterwards you can run the container and the report is written to the conf path.
+Change the configuration.json to your needs - see [Configuration](#configuration), afterwards you can run the container and the report is written to the output path.
 
 ```
 docker run --rm --name togglr -v ${PWD}/conf:/conf local/togglr:latest -c /conf/ -o /conf/

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ Successfully built 1b138810eb50
 Successfully tagged local/togglr:latest
 ```
 
-After the successfull build you can generate the configuration  but you need to mount a directory into the container to have the configuration.json file available.
+After the successful build, you can generate the configuration, but you need to mount a directory into the container to have the configuration.json file available.
 ```
 mkdir conf && docker run --rm --name togglr -v ${PWD}/conf:/conf local/togglr:latest generate-configuration -t /conf/configuration.json
 ```
 
-Change the configuration.json to your needs - see [Configuration](#configuration), afterwards you can run the container and the report is written to the conf path
+Change the configuration.json to your needs - see [Configuration](#configuration), afterwards you can run the container and the report is written to the conf path.
 
 ```
-docker run --rm --name togglr -v ${PWD}/conf:/conf local/togglr:latest -c /conf/configuration.json -o /conf/
+docker run --rm --name togglr -v ${PWD}/conf:/conf local/togglr:latest -c /conf/ -o /conf/
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ togglr --help
 Adliance.Togglr
 Adliance GmbH
 
+  project-time              Generates a detailed report for a specific project and time range.
+  
   generate-report           (Default Verb) Generate a report with specified configuration
 
   generate-configuration    Generate a template 'configuration.json' in the current folder
@@ -74,7 +76,9 @@ togglr generate-report --help
 Adliance.Togglr
 Adliance GmbH
 
-  -c, --configuration    (Default: configuration.json) Path to configuration file
+  -c, --configuration    (Default: ./) Path to configuration folder which holds "configuration.json" and eventually "entries.json"
+  
+  -o, --output-path      (Default: ./) Output path for report
 
   --help                 Display this help screen.
 

--- a/src/Adliance.Togglr/Html.cs
+++ b/src/Adliance.Togglr/Html.cs
@@ -8,8 +8,8 @@ namespace Adliance.Togglr;
 
 public class Html
 {
-    private StringBuilder _sb;
-    private ReportParameter _configuration;
+    private readonly StringBuilder _sb;
+    private readonly ReportParameter _configuration;
 
     public Html(ReportParameter configuration)
     {

--- a/src/Adliance.Togglr/Report/DayStatistics.cs
+++ b/src/Adliance.Togglr/Report/DayStatistics.cs
@@ -55,7 +55,7 @@ public static class DayStatistics
 
             if (loopDate.Date.DayOfWeek == DayOfWeek.Sunday && userData.Weeks.ContainsKey((loopDate.Date.Year, loopDate.Date.Month, loopDate.Date.GetWeekNumber())))
             {
-                WriteWeeklySummary(configuration, sb, loopDate.Date,  userData.Weeks[(loopDate.Date.Year, loopDate.Date.Month, loopDate.Date.GetWeekNumber())]);
+                WriteWeeklySummary(configuration, sb, loopDate.Date, userData.Weeks[(loopDate.Date.Year, loopDate.Date.Month, loopDate.Date.GetWeekNumber())]);
                 printedWeeklySummary = true;
             }
 

--- a/src/Adliance.Togglr/Report/ReportParameter.cs
+++ b/src/Adliance.Togglr/Report/ReportParameter.cs
@@ -6,6 +6,6 @@ namespace Adliance.Togglr.Report;
 
 public class ReportParameter
 {
-    [Option('c', "configuration", Required = false, Default = "configuration.json", HelpText = "Path to configuration file")] public string ConfigurationFilePath { get; set; } = "";
+    [Option('c', "configuration", Required = false, Default = "./", HelpText = "Path to configuration folder which holds \"configuration.json\" and eventually \"entries.json\"")] public string ConfigurationPath { get; set; } = "";
     [Option('o', "output-path", Required = false, Default = "./", HelpText = "Output path for report")] public string OutputPath { get; set; } = "";
 }

--- a/src/Adliance.Togglr/Report/ReportService.cs
+++ b/src/Adliance.Togglr/Report/ReportService.cs
@@ -15,6 +15,8 @@ public class ReportService(ReportParameter reportParameter)
 {
     private Configuration Configuration { get; set; } = new();
     public static List<DetailedReportDatum> AllEntries = new();
+    private const string ConfigurationFileName = "configuration.json";
+    private readonly string _configurationFilePath = Path.Combine(reportParameter.ConfigurationPath, ConfigurationFileName);
 
     public async Task<ExitCode> Run()
     {
@@ -23,11 +25,11 @@ public class ReportService(ReportParameter reportParameter)
 
         try
         {
-            Configuration = JsonConvert.DeserializeObject<Configuration>(await File.ReadAllTextAsync(reportParameter.ConfigurationFilePath)) ?? throw new Exception("Unable to deserialize configuration.");
+            Configuration = JsonConvert.DeserializeObject<Configuration>(await File.ReadAllTextAsync(_configurationFilePath)) ?? throw new Exception("Unable to deserialize configuration.");
         }
         catch (Exception ex)
         {
-            Program.Logger.Fatal(ex, $"Unable to load {reportParameter.ConfigurationFilePath}: {ex.Message}");
+            Program.Logger.Fatal(ex, $"Unable to load {_configurationFilePath}: {ex.Message}");
             return ExitCode.Error;
         }
 
@@ -39,7 +41,7 @@ public class ReportService(ReportParameter reportParameter)
 
         Program.Logger.Trace($"Loaded configuration with {Configuration.Users.Count} configured users.");
 
-        var togglClient = new TogglClient(Configuration);
+        var togglClient = new TogglClient(Configuration, reportParameter);
         await togglClient.DownloadEntriesAndStoreLocally();
         AllEntries = togglClient.LoadEntriesLocallyAndFix();
 

--- a/src/Adliance.Togglr/Report/TicketReportService.cs
+++ b/src/Adliance.Togglr/Report/TicketReportService.cs
@@ -70,7 +70,6 @@ public class TicketReportService(ReportParameter reportParameter)
                         + "</td>");
             _html.Write("</tr>");
 
-
             foreach (var ticket in project.Tickets.OrderByDescending(x => x.Hours))
             {
                 _html.Write("<tr data-project=\"" + project.Name + "\" class=\"is-hidden\">");

--- a/src/Adliance.Togglr/TogglClient.cs
+++ b/src/Adliance.Togglr/TogglClient.cs
@@ -17,7 +17,7 @@ namespace Adliance.Togglr;
 public class TogglClient
 {
     private readonly Configuration _configuration;
-    private static string _entriesFilePath = "";
+    private readonly string _entriesFilePath;
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
     private readonly DateTime _useOldEntriesUpToDate;
     private const int StartYear = 2015;

--- a/src/Adliance.Togglr/TogglClient.cs
+++ b/src/Adliance.Togglr/TogglClient.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Adliance.Togglr.Report;
 using Newtonsoft.Json;
 using NLog;
 using TogglApi.Client.Reports;
@@ -13,10 +14,20 @@ using TogglApi.Client.Reports.Models.Response;
 
 namespace Adliance.Togglr;
 
-public class TogglClient (Configuration configuration)
+public class TogglClient
 {
+    private readonly Configuration _configuration;
+    private static string _entriesFilePath = "";
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
-    private readonly DateTime _useOldEntriesUpToDate = DateTime.UtcNow.AddDays(-configuration.UseOldEntriesXDaysBack);
+    private readonly DateTime _useOldEntriesUpToDate;
+    private const int StartYear = 2015;
+
+    public TogglClient(Configuration configuration, ReportParameter reportParameter)
+    {
+        _configuration = configuration;
+        _useOldEntriesUpToDate = DateTime.UtcNow.AddDays(-_configuration.UseOldEntriesXDaysBack);
+        _entriesFilePath = Path.Combine(reportParameter.ConfigurationPath, "entries.json");
+    }
 
     private async Task<IEnumerable<DetailedReportDatum>> DownloadEntries(DateTime from, DateTime to)
     {
@@ -27,11 +38,11 @@ public class TogglClient (Configuration configuration)
         var detailedReports = (await client.GetDetailedReport(new DetailedReportConfig
         (
             userAgent: "Adliance.Togglr by Adliance GmbH",
-            workspaceId: configuration.WorkspaceId, //Adliance workspace
+            workspaceId: _configuration.WorkspaceId, //Adliance workspace
             since: from,
             until: to,
             billableOptions: BillableOptions.Both
-        ), apiToken: configuration.ApiToken)).Data.OrderBy(x => x.Start);
+        ), apiToken: _configuration.ApiToken)).Data.OrderBy(x => x.Start);
 
         return detailedReports;
     }
@@ -41,21 +52,21 @@ public class TogglClient (Configuration configuration)
         var entries = new List<DetailedReportDatum>();
 
         // check if file with old entries already exists; otherwise download all entries
-        if (!File.Exists("entries.json"))
+        if (!File.Exists(_entriesFilePath))
         {
-            for (var i = 2015; i <= DateTime.UtcNow.Year; i++)
+            for (var i = StartYear; i <= DateTime.UtcNow.Year; i++)
             {
                 entries.AddRange(await DownloadEntries(
                     new DateTime(i, 1, 1),
                     new DateTime(i, 12, 31).AddDays(1).AddSeconds(-1)));
             }
 
-            await File.WriteAllTextAsync("entries.json", JsonConvert.SerializeObject(entries));
+            await File.WriteAllTextAsync(_entriesFilePath, JsonConvert.SerializeObject(entries));
         }
         else
         {
             // determine last entry in existing file
-            var existingEntries = JsonConvert.DeserializeObject<List<DetailedReportDatum>>(await File.ReadAllTextAsync("entries.json")) ?? new List<DetailedReportDatum>();
+            var existingEntries = JsonConvert.DeserializeObject<List<DetailedReportDatum>>(await File.ReadAllTextAsync(_entriesFilePath)) ?? new List<DetailedReportDatum>();
             var lastRelevantEntry = existingEntries.Where(x => x.End < _useOldEntriesUpToDate).OrderBy(x => x.End).Last();
 
             // load new entries from date of last relevant entry on
@@ -66,7 +77,7 @@ public class TogglClient (Configuration configuration)
             var allEntries = existingEntries.Concat(entries).ToList();
             allEntries = allEntries.GroupBy(x => x.Id)
                 .Select(x => x.OrderByDescending(y => y.Updated).First()).ToList();
-            await File.WriteAllTextAsync("entries.json", JsonConvert.SerializeObject(allEntries));
+            await File.WriteAllTextAsync(_entriesFilePath, JsonConvert.SerializeObject(allEntries));
         }
 
         _logger.Info($"Downloaded a total of {entries.Count:N0} time entries.");
@@ -74,7 +85,7 @@ public class TogglClient (Configuration configuration)
 
     public List<DetailedReportDatum> LoadEntriesLocallyAndFix()
     {
-        var entries = JsonConvert.DeserializeObject<List<DetailedReportDatum>>(File.ReadAllText("entries.json")) ?? new List<DetailedReportDatum>();
+        var entries = JsonConvert.DeserializeObject<List<DetailedReportDatum>>(File.ReadAllText(_entriesFilePath)) ?? new List<DetailedReportDatum>();
 
         var fixedEntries = new List<DetailedReportDatum>();
         foreach (var entry in entries)


### PR DESCRIPTION
As stated in #17, the `-c` option for `generate-report` is now a folder path for the configuration instead of a file path to the configuration file as the configuration folder contains `configuration.json` and eventually already `entries.json`.

That way the `entries.json` file can be used properly in the docker environment by mounting the whole configuration folder.